### PR TITLE
[WIP] feat: use mutable state instead of livedata

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.0'
     implementation "androidx.navigation:navigation-compose:2.5.3"
 
     // see -> https://developer.android.com/jetpack/androidx/releases/compose-compiler

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/data/IRepository.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/data/IRepository.kt
@@ -2,12 +2,11 @@ package com.github.mrpaulblack.personalrecipes.data
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.MutableLiveData
 import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
 
 
 interface IRepository {
-    fun getOverview(): MutableLiveData<List<RecipeModel>>
-    fun getDetailedRecipe(meal: String): MutableLiveData<RecipeModel>
-    fun queryRecipe(query: MutableState<TextFieldValue>): MutableLiveData<List<RecipeModel>>
+    fun getOverview(): MutableState<List<RecipeModel>>
+    fun getDetailedRecipe(meal: String): MutableState<RecipeModel>
+    fun queryRecipe(query: MutableState<TextFieldValue>): MutableState<List<RecipeModel>>
 }

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/data/Repository.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/data/Repository.kt
@@ -2,7 +2,6 @@ package com.github.mrpaulblack.personalrecipes.data
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.MutableLiveData
 import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
 
 
@@ -10,17 +9,17 @@ class Repository : IRepository {
     private val firebaseDB: IRepository = Firebase()
 
 
-    override fun getOverview(): MutableLiveData<List<RecipeModel>> {
+    override fun getOverview(): MutableState<List<RecipeModel>> {
         return firebaseDB.getOverview()
     }
 
 
-    override fun getDetailedRecipe(meal: String): MutableLiveData<RecipeModel> {
+    override fun getDetailedRecipe(meal: String): MutableState<RecipeModel> {
         return firebaseDB.getDetailedRecipe(meal)
     }
 
 
-    override fun queryRecipe(query: MutableState<TextFieldValue>): MutableLiveData<List<RecipeModel>> {
+    override fun queryRecipe(query: MutableState<TextFieldValue>): MutableState<List<RecipeModel>> {
         return firebaseDB.queryRecipe(query)
     }
 }

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/recipe/RecipeView.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/recipe/RecipeView.kt
@@ -10,8 +10,8 @@ import androidx.compose.material.icons.rounded.Scale
 import androidx.compose.material.icons.rounded.Source
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -40,7 +40,7 @@ object RecipeView {
         viewModel: RecipeViewModel = koinViewModel()
     ) {
         viewModel.setRecipe(backStackEntry.arguments?.getString("recipeName") ?: "")
-        val recipe: RecipeModel by viewModel.recipe.observeAsState(initial = RecipeModel())
+        val recipe: MutableState<RecipeModel> = remember { viewModel.recipe }
 
         Surface(
             modifier = modifier
@@ -53,8 +53,8 @@ object RecipeView {
                     contentAlignment = Alignment.BottomStart
                 ) {
                     RecipeImage.Content(
-                        model = recipe.image,
-                        contentDescription = recipe.source,
+                        model = recipe.value.image,
+                        contentDescription = recipe.value.source,
                         Modifier.height(240.dp)
                     )
                     Column(
@@ -68,7 +68,7 @@ object RecipeView {
                             )
                         }
                         Text(
-                            text = recipe.label,
+                            text = recipe.value.label,
                             style = MaterialTheme.typography.headlineLarge.copy(
                                 shadow = Shadow (
                                     color = Color.Black,
@@ -89,17 +89,17 @@ object RecipeView {
                         InfoCard.Content(
                             icon = Icons.Rounded.Scale,
                             label = stringResource(R.string.recipe_weight),
-                            value = String.format("%.2f", recipe.totalWeight)
+                            value = String.format("%.2f", recipe.value.totalWeight)
                         )
                         InfoCard.Content(
                             icon = Icons.Rounded.MonitorWeight,
                             label = stringResource(R.string.recipe_calories),
-                            value = String.format("%.2f", recipe.calories)
+                            value = String.format("%.2f", recipe.value.calories)
                         )
                         InfoCard.Content(
                             icon = Icons.Rounded.Source,
                             label = stringResource(R.string.recipe_source),
-                            value = recipe.source
+                            value = recipe.value.source
                         )
                     }
                     Spacer(modifier = Modifier.height(24.dp))
@@ -108,14 +108,14 @@ object RecipeView {
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.headlineMedium
                     )
-                    IngredientsCard.Content(recipe.ingredients)
+                    IngredientsCard.Content(recipe.value.ingredients)
                     Column(
                         modifier = Modifier.padding(12.dp)
                     ) {
-                        RecipeCard("Health Labels: ", recipe.healthLabels)
-                        RecipeCard("Tools: ", recipe.tools)
-                        RecipeCard("Diet Labels: ", recipe.dietLabels)
-                        RecipeCard("Cautions: ", recipe.cautions)
+                        RecipeCard("Health Labels: ", recipe.value.healthLabels)
+                        RecipeCard("Tools: ", recipe.value.tools)
+                        RecipeCard("Diet Labels: ", recipe.value.dietLabels)
+                        RecipeCard("Cautions: ", recipe.value.cautions)
                     }
                 }
             }

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/recipe/RecipeViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.mrpaulblack.personalrecipes.ui.recipe
 
-import androidx.lifecycle.MutableLiveData
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.github.mrpaulblack.personalrecipes.data.IRepository
 import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
@@ -9,7 +10,7 @@ import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
 class RecipeViewModel(
     private val data: IRepository
 ): ViewModel() {
-    var recipe: MutableLiveData<RecipeModel> = MutableLiveData(RecipeModel())
+    var recipe: MutableState<RecipeModel> = mutableStateOf(RecipeModel())
 
 
     fun setRecipe(recipeName: String) {

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/recipeslist/RecipesListView.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/recipeslist/RecipesListView.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
@@ -25,15 +25,13 @@ object RecipesListView {
         modifier: Modifier = Modifier,
         viewModel: RecipesListViewModel = koinViewModel()
     ) {
-        val recipesList: List<RecipeModel> by viewModel.recipesList.observeAsState(
-            initial = listOf()
-        )
+        val recipesList: MutableState<List<RecipeModel>> = remember {viewModel.recipesList}
 
         Surface(
             modifier = modifier.fillMaxSize()
         ) {
             Column {
-                AnimatedVisibility(visible = recipesList.isEmpty()) {
+                AnimatedVisibility(visible = recipesList.value.isEmpty()) {
                     LinearProgressIndicator(modifier = Modifier
                         .height(2.dp)
                         .fillMaxWidth())
@@ -44,8 +42,8 @@ object RecipesListView {
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     modifier = Modifier.padding(horizontal = 12.dp)
                 ) {
-                    items (recipesList.size) {
-                        RecipeCard.Content(recipesList[it], onClick)
+                    items (recipesList.value.size) {
+                        RecipeCard.Content(recipesList.value[it], onClick)
                     }
                 }
             }

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/search/SearchView.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/search/SearchView.kt
@@ -7,8 +7,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.*
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -31,7 +30,7 @@ object SearchView {
     ) {
         val textState = remember { viewModel.textState }
         viewModel.query(textState)
-        val recipesList: List<RecipeModel> by viewModel.recipes.observeAsState(initial = listOf())
+        val recipesList: MutableState<List<RecipeModel>> = remember {viewModel.recipes}
 
         Surface(
             modifier = modifier.fillMaxSize()
@@ -50,8 +49,8 @@ object SearchView {
                 Spacer(modifier = Modifier.height(12.dp))
                 LazyVerticalGrid(columns = GridCells.Fixed(1)) {
                     if (textState.value.text != "") {
-                        items (recipesList.size) {
-                            RecipeListItem.Content(recipe = recipesList[it], onClick = onClick)
+                        items (recipesList.value.size) {
+                            RecipeListItem.Content(recipe = recipesList.value[it], onClick = onClick)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/mrpaulblack/personalrecipes/ui/search/SearchViewModel.kt
@@ -3,7 +3,6 @@ package com.github.mrpaulblack.personalrecipes.ui.search
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.github.mrpaulblack.personalrecipes.data.IRepository
 import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
@@ -12,7 +11,7 @@ import com.github.mrpaulblack.personalrecipes.data.models.RecipeModel
 class SearchViewModel(
     private val data: IRepository
 ) : ViewModel() {
-    var recipes: MutableLiveData<List<RecipeModel>> = MutableLiveData(listOf())
+    var recipes: MutableState<List<RecipeModel>> = mutableStateOf(listOf())
     val textState =  mutableStateOf(TextFieldValue())
 
 


### PR DESCRIPTION
### Fix in this PR
* currently the search query does not work
* I would also prefer to initialize vars from viewModels with delegates (by) instead of assigning the state to the vars


### TODO
* initialize vars from viewModels with delegates (by) instead of assigning the state to the vars
see -> https://stackoverflow.com/questions/70487159/compose-mutablestate-from-viewmodel
* fix search view; refactor repository to return query result that is display in the ui
see -> https://cloud.google.com/firestore/docs/query-data/queries#kotlin+ktxandroid
see -> https://medium.com/firebase-tips-tricks/how-to-filter-firestore-in-real-time-using-jetpack-compose-952abaab15c5
see -> https://stackoverflow.com/questions/46568142/google-firestore-query-on-substring-of-a-property-value-text-search
* use custom animations between switching views and build own custom splash screen on startup; add loading animations for repository requests and display error if any (maybe its possible to remove `com.google.material` dep, when removing fallback xml theme?)
see -> https://m3.material.io/theme-builder#/custom
see -> https://fonts.google.com/icons?icon.style=Rounded&icon.category=Household&icon.set=Material+Symbols
see -> https://developer.android.com/jetpack/compose/animation#animatedvisibility
see -> https://developer.android.com/jetpack/compose/animation
see -> https://developer.android.com/jetpack/compose/designsystems/material3
see -> https://m3.material.io/components/search/overview
* add placeholder elements if the recipe is still loading in recipe detail view (maybe even for images?)
see -> https://google.github.io/accompanist/placeholder/
see -> https://coil-kt.github.io/coil/compose/
* fix recipe detail view: move arrow to top left of screen and add shadow to arrow
see -> https://foso.github.io/Jetpack-Compose-Playground/layout/box/
see -> https://stackoverflow.com/questions/74582134/how-to-overlay-texts-on-an-image-using-jetpack-compose
* finish up recipe detail view information
* build ci/cd with github actions
* update readme with dev steps and info about the app
* build prod builds and deploy somewhere?
* splash screen and remove `com.google.material` dep:
see -> https://github.com/revanced/revanced-manager-compose

### MVVM examples
* https://medium.com/@ffvanderlaan/navigation-in-jetpack-compose-using-viewmodel-state-3b2517c24dde
* https://github.com/Frank1234/ViewModelNavigationCompose/tree/master/app/src/main/java/nl/frank/vmnc
* https://learn.microsoft.com/en-us/dotnet/architecture/maui/mvvm